### PR TITLE
Fixup configuration to support scalatest 3.2.0.

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -1,6 +1,5 @@
 jar_library(name='scalatest',
             jars=[
-                scala_jar(org='org.scalatest', name='scalatest', rev='3.2.3'),
-                scala_jar(org='org.scalatestplus', name='scalacheck-1-15', rev='3.2.3.0'),
-                scala_jar(org='org.scalatestplus', name='junit-4-13', rev='3.2.3.0')
+                scala_jar(org='org.scalatest', name='scalatest', rev='3.2.0'),
+                scala_jar(org='org.scalatestplus', name='scalacheck-1-14', rev='3.2.0.0'),
             ])

--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -2,4 +2,5 @@ jar_library(name='scalatest',
             jars=[
                 scala_jar(org='org.scalatest', name='scalatest', rev='3.2.0'),
                 scala_jar(org='org.scalatestplus', name='scalacheck-1-14', rev='3.2.0.0'),
+                scala_jar(org='org.scalatestplus', name='junit-4-12', rev='3.2.0.0'),
             ])

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -22,6 +22,5 @@ jar_library(name='scala-reflect',
 
 jar_library(name='junit',
             jars=[
-                jar(org='org.pantsbuild', name='junit-runner', rev='1.0.29'),
-                scala_jar(org='org.scalatestplus', name='junit-4-12', rev='3.2.0.0')
+                jar(org='org.pantsbuild', name='junit-runner', rev='1.0.30'),
             ])

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -19,3 +19,9 @@ jar_library(name='scala-reflect',
             jars=[
                 jar(org='org.scala-lang', name='scala-reflect', rev=SCALA_REV, intransitive=True),
             ])
+
+jar_library(name='junit',
+            jars=[
+                jar(org='org.pantsbuild', name='junit-runner', rev='1.0.29'),
+                scala_jar(org='org.scalatestplus', name='junit-4-12', rev='3.2.0.0')
+            ])

--- a/test/scala/com/github/slvrtrn/TestHello.scala
+++ b/test/scala/com/github/slvrtrn/TestHello.scala
@@ -18,6 +18,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 class TestHello extends AnyFlatSpec {
 
   it should "pass" in {
-    assert(true)
+    assert(false)
   }
 }

--- a/test/scala/com/github/slvrtrn/TestHello.scala
+++ b/test/scala/com/github/slvrtrn/TestHello.scala
@@ -1,8 +1,6 @@
 package com.github.slvrtrn
 
-import org.junit.runner.RunWith
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatestplus.junit.JUnitRunner
 
 /**
   * ScalaTest 3.0.8 works without the annotation
@@ -17,7 +15,6 @@ import org.scalatestplus.junit.JUnitRunner
   *
   * but works fine if the annotation is uncommented
   */
-//@RunWith(classOf[JUnitRunner])
 class TestHello extends AnyFlatSpec {
 
   it should "pass" in {


### PR DESCRIPTION
This now nets:
```
$ ./pants clean-all test.junit --output-mode=ALL ::

06:20:24 00:00 [main]
               (To run a reporting server: ./pants server)
06:20:24 00:00   [setup]
06:20:24 00:00     [parse]
               Executing tasks in goals: clean-all -> bootstrap -> imports -> unpack-jars -> unpack-wheels -> deferred-sources -> native-compile -> link -> jvm-platform-validate -> gen -> pyprep -> resolve -> resources -> compile -> test
06:20:25 00:01   [clean-all]
06:20:25 00:01     [ng-killall]
06:20:25 00:01     [kill-pantsd]
06:20:25 00:01     [clean-all]14:20:25 [INFO] For async removal, run `./pants clean-all --async`

06:20:25 00:01   [bootstrap]
06:20:25 00:01     [substitute-aliased-targets]
06:20:25 00:01     [jar-dependency-management]
06:20:25 00:01     [bootstrap-jvm-tools]
06:20:25 00:01     [provide-tools-jar]
06:20:25 00:01   [imports]
06:20:25 00:01     [ivy-imports]
06:20:25 00:01   [unpack-jars]
06:20:25 00:01     [unpack-jars]
06:20:25 00:01   [unpack-wheels]
06:20:25 00:01     [unpack-wheels]
06:20:25 00:01   [deferred-sources]
06:20:25 00:01     [deferred-sources]
06:20:25 00:01   [native-compile]
06:20:25 00:01     [conan-prep]
06:20:25 00:01     [conan-fetch]
06:20:25 00:01     [c-for-ctypes]
06:20:25 00:01     [cpp-for-ctypes]
06:20:26 00:02   [link]
06:20:26 00:02     [shared-libraries]
06:20:26 00:02   [jvm-platform-validate]
06:20:26 00:02     [jvm-platform-validate]
06:20:26 00:02       [cache]  
                   No cached artifacts for 2 targets.
                   Invalidated 2 targets.
06:20:26 00:02   [gen]
06:20:26 00:02     [protoc]
06:20:26 00:02     [thrift-java]
06:20:26 00:02     [thrift-py]
06:20:26 00:02     [py-thrift-namespace-clash-check]
06:20:26 00:02     [grpcio-prep]
06:20:26 00:02     [grpcio-run]
06:20:26 00:02   [pyprep]
06:20:26 00:02     [interpreter]
06:20:26 00:02     [build-local-dists]
06:20:26 00:02     [requirements]
06:20:26 00:02     [sources]
06:20:26 00:02   [resolve]
06:20:26 00:02     [coursier]
06:20:26 00:02       [cache] 
                   No cached artifacts for 1 target.
                   Invalidated 1 target. 
06:20:27 00:03       [coursier]
06:20:28 00:04       [cache] 
                   No cached artifacts for 7 targets.
                   Invalidated 7 targets. 
06:20:28 00:04       [coursier]
06:20:31 00:07   [resources]
06:20:31 00:07     [prepare]
06:20:31 00:07     [services]
06:20:31 00:07   [compile]
06:20:31 00:07     [compile-jvm-prep-command]
06:20:31 00:07       [jvm_prep_command]
06:20:31 00:07     [compile-prep-command]
06:20:31 00:07     [compile]
06:20:31 00:07     [rsc]
06:20:31 00:07       [cache]  
                   No cached artifacts for 2 targets.
                   Invalidated 2 targets.
06:20:31 00:07       [isolation-mixed-pool-bootstrap]  
                   [1/2] Compiling 1 mixed source in 1 target (src/scala/com/github/slvrtrn:hello).
                   [2/2] Compiling 1 mixed source in 1 target (test/scala/com/github/slvrtrn:tests).
06:20:31 00:07       [compile]
                     
06:20:31 00:07       [compile]
                     
06:20:31 00:07         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:20:31 00:07         [coursier]
06:20:33 00:09         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target.
06:20:33 00:09         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:20:33 00:09         [coursier]
06:20:37 00:13         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:20:37 00:13         [coursier]
06:20:40 00:16         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:20:40 00:16         [coursier]
06:20:42 00:18         [shade-zinc]
06:20:58 00:34         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target.
06:20:58 00:34         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:20:58 00:34         [coursier]
06:20:59 00:35         [shade-compiler-interface]
06:20:59 00:35         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:20:59 00:35         [coursier]
06:21:01 00:37         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target.
06:21:01 00:37         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:21:01 00:37         [coursier]
06:21:04 00:40         [shade-zinc-bootstrapper]
06:21:18 00:54         [zinc-subsystem]
06:21:26.08 [INFO] Completed: bootstrap compiler bridge.
[info] Non-compiled module 'compiler-interface' for Scala 2.12.8. Compiling...
                       [info]   Compilation completed in 7.017s.
                       
06:21:26 01:02         [cache] 
                     No cached artifacts for 1 target.
                     Invalidated 1 target. 
06:21:26 01:02         [coursier]
06:21:27 01:03         [mixed]
                       
06:21:27 01:03         [mixed]
                       [info] Compiling 1 Scala source to /home/jsirois/dev/slvrtrn/jsirois-pants-1.30-junit-scalatest-issue/.pants.d/compile/rsc/c1e3836b60e5/src.scala.com.github.slvrtrn.hello/current/zinc/classes ...
                       [info] Compiling 1 Scala source to /home/jsirois/dev/slvrtrn/jsirois-pants-1.30-junit-scalatest-issue/.pants.d/compile/rsc/c1e3836b60e5/test.scala.com.github.slvrtrn.tests/current/zinc/classes ...
                       [info] Done compiling.
                       [info] Compile success at Jan 14, 2021 6:21:32 AM [4.242s]
                       [info] Done compiling.
                       [info] Compile success at Jan 14, 2021 6:21:32 AM [4.241s]
                       
06:21:32 01:08     [javac]
06:21:32 01:08   [test]
06:21:32 01:08     [test-jvm-prep-command]
06:21:32 01:08       [jvm_prep_command]
06:21:32 01:08     [test-prep-command]
06:21:32 01:08     [legacy]
06:21:32 01:08     [pytest-prep]
06:21:32 01:08     [pytest]
06:21:32 01:08     [junit]
06:21:32 01:08       [cache] 
                   No cached artifacts for 1 target.
                   Invalidated 1 target.
06:21:32 01:08       [cache] 
                   No cached artifacts for 1 target.
                   Invalidated 1 target.
06:21:32 01:08       [cache] 
                   No cached artifacts for 1 target.
                   Invalidated 1 target. 
06:21:32 01:08       [coursier]
06:21:35 01:11       [shade-junit]
06:21:43 01:19       [run]
                     Auto-detected 8 processors, using -parallel-threads=8
                     
                     Time: 0.001
                     
                     OK (0 tests)
                     
                     
                   test/scala/com/github/slvrtrn:tests                                             .....   SUCCESS
               Waiting for background workers to finish.
06:21:43 01:19   [complete]
               SUCCESS
```